### PR TITLE
Added BudgetItem container and BudgetItemDetail component.

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -20,11 +20,12 @@ exports[`renders correctly 1`] = `
     >
       Description
     </div>
-    <div
-      className="cellContent"
+    <a
+      href="/budget/1"
+      onClick={[Function]}
     >
       Trader Joe's food
-    </div>
+    </a>
   </td>
   <td
     className="neg"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
+import { MemoryRouter } from 'react-router-dom'; //because the <Link> added in BudgetGridRow
 
 it('renders correctly', () => {
   const mockTransaction = {
@@ -15,6 +16,10 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer.create(
+    <MemoryRouter>
+      <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+    </MemoryRouter>
+  ).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -4,6 +4,7 @@ import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
 import styles from './style.scss';
+import {Link} from 'react-router-dom';
 
 type BudgetGridRowProps = {
   transaction: Transaction,
@@ -24,7 +25,7 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       </td>
       <td>
         <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
+        <Link to={'/budget/' + id}>{description}</Link>        
       </td>
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>

--- a/app/components/BudgetItemDetail/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetItemDetail/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="budgetItem"
+>
+  <div>
+    <h2>
+      Trader Joe's food
+       
+      <span
+        className="category"
+      >
+        Groceries
+      </span>
+    </h2>
+    <h4>
+      <span
+        className="neg"
+      >
+        %9.23
+      </span>
+    </h4>
+    <div
+      className="donutChart"
+    >
+      <div
+        height={316}
+        padding={8}
+        transform="translate(150,150)"
+        width={316}
+      />
+      <div
+        color={[Function]}
+        data={
+          Array [
+            Object {
+              "category": "Trader Joe's food",
+              "categoryId": 1,
+              "value": 9.23,
+            },
+            Object {
+              "category": "Others",
+              "categoryId": 0,
+              "value": 90.77,
+            },
+          ]
+        }
+        dataKey="categoryId"
+        dataLabel="category"
+        dataValue="value"
+        usePercentSign={true}
+      />
+    </div>
+    <input
+      className="button"
+      onClick={[Function]}
+      type="submit"
+      value="Back"
+    />
+  </div>
+</div>
+`;
+
+exports[`renders correctly no Transaction 1`] = `
+<div
+  className="budgetItem"
+>
+  <div>
+    <h2>
+      <span
+        className="notFound"
+      >
+        Transaction not found
+      </span>
+    </h2>
+    <br />
+    <input
+      className="button"
+      onClick={[Function]}
+      type="submit"
+      value="Back"
+    />
+  </div>
+</div>
+`;

--- a/app/components/BudgetItemDetail/__tests__/index-test.js
+++ b/app/components/BudgetItemDetail/__tests__/index-test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BudgetItemDetail from 'components/BudgetItemDetail';
+
+// mock nested components
+jest.mock('components/DonutChart/Path');
+jest.mock('components/Chart', () => 'div');
+jest.mock('components/Legend', () => 'div');
+
+it('renders correctly', () => {
+  const mockTransaction = {
+    id: 1,
+    description: "Trader Joe's food",
+    value: -423.34,
+    categoryId: 1,
+  };
+
+  const mockCategory = 'Groceries';
+
+  const mockPercent = 9.23;
+
+  const tree = renderer.create(    
+      <BudgetItemDetail transaction={mockTransaction} category={mockCategory} percent={mockPercent} redirectToBudget={()=>{}} />          
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders correctly no Transaction', () => {
+  const mockTransaction = {};
+
+  const mockCategory = '';
+
+  const mockPercent = 0;
+
+  const tree = renderer.create(    
+      <BudgetItemDetail transaction={mockTransaction} category={mockCategory} percent={mockPercent} redirectToBudget={()=>{}} />          
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/BudgetItemDetail/index.js
+++ b/app/components/BudgetItemDetail/index.js
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { formatPercent } from 'utils/formatAmount';
+import type { Transaction } from 'modules/transactions';
+import styles from './style.scss';
+import DonutChart from 'components/DonutChart';
+
+type BudgetItemDetailProps = {
+    transaction: Transaction,
+    category: {},
+    percent: number,
+    redirectToBudget: {},
+};
+
+const categoryDataItem = (categoryId, value, description) => {
+    return {
+        categoryId,
+        value,
+        category: description,
+    };
+}
+const BudgetItemDetail = ({ transaction, category, percent, redirectToBudget }: BudgetItemDetailProps) => {
+
+    const isValidTransaction = transaction.id != undefined;
+    const invalidTransactionMessage = "Transaction not found";
+    const { id, categoryId, description } = transaction;
+    const formatedPercent = formatPercent(percent);
+    const isNegative = transaction.value < 0;
+    const amountCls = isNegative ? styles.neg : styles.pos;
+
+    const data = [
+        categoryDataItem(categoryId, percent, description),
+        categoryDataItem(0, 100 - percent, "Others"),
+    ];
+
+    const BackButton = () => {
+        return <input type="submit"
+            value="Back"
+            className={styles.button}
+            onClick={redirectToBudget} />
+    };
+    return (
+
+        <div className={styles.budgetItem}>
+            {isValidTransaction ? (<div>
+                <h2>{description} <span className={styles.category}>{category}</span></h2>
+                <h4><span className={amountCls}>{formatedPercent}</span></h4>
+                <DonutChart data={data} dataLabel="category" dataKey="categoryId" usePercentSign={true} />
+                <BackButton />
+            </div>
+            ) : (<div>
+                <h2><span className={styles.notFound}>{invalidTransactionMessage}</span></h2><br/>
+                <BackButton />
+            </div>)}
+        </div>
+    );
+};
+
+export default BudgetItemDetail;

--- a/app/components/BudgetItemDetail/style.scss
+++ b/app/components/BudgetItemDetail/style.scss
@@ -1,0 +1,54 @@
+@import 'theme/variables';
+
+.budgetItem {
+  display: flex;
+  flex-flow: column;  
+  font-size: 0.8em;  
+  @media only screen and (max-width: $screen-small) {    
+    align-items: center;   
+    text-align: center;    
+  }    
+}
+
+.neg {
+  color: $red;
+}
+.neg:before {
+  content: "-";
+}
+.pos {
+  color: $green;
+}
+.pos:before {
+  content: "+";
+}
+.category {
+  font-weight: lighter;
+  font-style: italic;
+  color:rgb(72, 72, 72); 
+}
+.category:after {
+  content: "]";
+}
+.category:before {
+  content: "[";
+}
+.button {
+  color: #fff;  
+  text-transform: uppercase;
+  background: rgb(28, 184, 65);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  padding: .5em 1em;
+  text-decoration: none;
+  border: transparent;
+
+  width: 60px;
+  @media only screen and (max-width: $screen-small) {    
+    width:100%;
+  }  
+}
+
+.notFound {
+  color: $red;  
+}

--- a/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/DonutChart/__tests__/__snapshots__/index-test.js.snap
@@ -16,6 +16,7 @@ exports[`renders correctly 1`] = `
     dataKey="test"
     dataLabel="test"
     dataValue="value"
+    usePercentSign={false}
   />
 </div>
 `;

--- a/app/components/DonutChart/__tests__/index-test.js
+++ b/app/components/DonutChart/__tests__/index-test.js
@@ -8,6 +8,6 @@ jest.mock('components/Chart', () => 'div');
 jest.mock('components/Legend', () => 'div');
 
 it('renders correctly', () => {
-  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
+  const tree = renderer.create(<DonutChart dataLabel="test" dataKey="test" data={[]} usePercentSign={false} />).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -19,6 +19,7 @@ type DonutChartProps = {
   color: Function,
   height: number,
   innerRatio: number,
+  usePercentSign: boolean,
 };
 
 class DonutChart extends React.Component<DonutChartProps> {
@@ -70,7 +71,7 @@ class DonutChart extends React.Component<DonutChartProps> {
   };
 
   render() {
-    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { data, dataLabel, dataValue, dataKey, usePercentSign } = this.props;
     const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
 
     return (
@@ -86,7 +87,7 @@ class DonutChart extends React.Component<DonutChartProps> {
           ))}
         </Chart>
 
-        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey, usePercentSign }} />
       </div>
     );
   }

--- a/app/components/Legend/LegendItem.js
+++ b/app/components/Legend/LegendItem.js
@@ -1,18 +1,19 @@
 // @flow
 import * as React from 'react';
-import formatAmount from 'utils/formatAmount';
+import formatAmount , { formatPercent } from 'utils/formatAmount';
 import styles from './styles.scss';
 
 type LegendItemProps = {
   color: string,
   value: number,
   label: string,
+  usePercentSign: boolean,
 };
 
-const LegendItem = ({ color, label, value }: LegendItemProps) => (
+const LegendItem = ({ color, label, value, usePercentSign }: LegendItemProps) => (
   <li style={{ color }}>
     <span>{label}</span>
-    <span className={styles.value}> {formatAmount(value).text} </span>
+    <span className={styles.value}> { usePercentSign? formatPercent(value) : formatAmount(value).text } </span>
   </li>
 );
 

--- a/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
@@ -7,11 +7,13 @@ exports[`renders correctly 1`] = `
   <div
     color={undefined}
     label={undefined}
+    usePercentSign={false}
     value={undefined}
   />
   <div
     color={undefined}
     label={undefined}
+    usePercentSign={false}
     value={undefined}
   />
 </ul>

--- a/app/components/Legend/__tests__/index-test.js
+++ b/app/components/Legend/__tests__/index-test.js
@@ -9,7 +9,7 @@ it('renders correctly', () => {
   const mockData = [{ key: 1 }, { key: 2 }];
 
   const tree = renderer
-    .create(<Legend data={mockData} dataValue="test" dataLabel="test" dataKey="key" color={() => {}} />)
+    .create(<Legend data={mockData} dataValue="test" dataLabel="test" dataKey="key" color={() => {}} usePercentSign={false}/>)
     .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -12,18 +12,20 @@ type LegendType = {
   dataKey: string,
   color: Function,
   reverse: boolean,
+  usePercentSign: boolean,
 };
 
-const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
+const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse, usePercentSign }: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
-      <LegendItem color={color(idx)} key={item[dataKey]} label={item[dataLabel]} value={item[dataValue]} />
+      <LegendItem color={color(idx)} key={item[dataKey]} label={item[dataLabel]} value={item[dataValue]} usePercentSign={usePercentSign} />
     ))}
   </ul>
 );
 
 Legend.defaultProps = {
   reverse: false,
+  usePercentSign: false,
 };
 
 export default Legend;

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import BudgetItem from 'containers/BudgetItem';
 import './style.scss';
 
 const App = () => (
@@ -14,8 +15,9 @@ const App = () => (
     <main>
       <Header />
 
-      <Switch>
-        <Route path="/budget" component={Budget} />
+      <Switch>        
+        <Route exact path="/budget" component={Budget} />
+        <Route path="/budget/:id" component={BudgetItem} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  category=""
+  percent={0}
+  redirectToBudget={[Function]}
+  transaction={Object {}}
+/>
+`;

--- a/app/containers/BudgetItem/__tests__/index-test.js
+++ b/app/containers/BudgetItem/__tests__/index-test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { BudgetItem } from '../index';
+
+// mock nested components
+jest.mock('components/DonutChart/Path');
+jest.mock('components/BudgetItemDetail', () => 'div');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<BudgetItem />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { getTransactions, getOutflowBalance, getInflowBalance } from 'selectors/transactions';
+import { getCategories } from 'selectors/categories';
+import type { Transaction } from 'modules/transactions';
+import BudgetItemDetail from 'components/BudgetItemDetail';
+import { inflowCategories } from 'modules/defaults';
+
+import transactionReducer from 'modules/transactions';
+import categoryReducer from 'modules/categories';
+import { injectAsyncReducers } from 'store';
+
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+    transactions: transactionReducer,
+    categories: categoryReducer,
+});
+
+type BudgetItemProps = {
+    transaction: Transaction,
+    categories: Object,
+};
+
+export class BudgetItem extends React.Component<BudgetItemProps> {   
+    constructor(props) {
+        super(props);
+        this.redirectToBudget = this.redirectToBudget.bind(this);
+    }
+    static defaultProps = {
+        transaction: {},
+        category: '',
+        percent:0,
+    };
+    redirectToBudget() {        
+        this.props.history.push('/budget');
+    }
+    render() {
+        const { transaction, category, percent} = this.props;
+
+        return (
+            <BudgetItemDetail 
+                transaction={transaction} 
+                category={category} 
+                percent={percent}
+                redirectToBudget={this.redirectToBudget}/>
+        );
+    }
+}
+
+const mapStateToProps = (state, ownProps) => {
+    const queryParams = ownProps.location.pathname.split('/');
+    const tId = queryParams[queryParams.length - 1];
+    const transactions = getTransactions(state);
+    const categories = getCategories(state);
+    
+    let transaction = transactions.find(t => t.id == tId);
+    let category = {};
+    let totalBalance = 0;
+    let percent = 0;
+
+    if (transaction) {        
+        category = categories[transaction.categoryId];                
+        if (inflowCategories.includes(transaction.categoryId))                    
+            totalBalance = getInflowBalance(state);
+        else                
+            totalBalance = getOutflowBalance(state);        
+        percent = transaction.value * 100 / totalBalance;
+    };       
+    return {
+        transaction,
+        category,        
+        percent,        
+    };
+};
+
+export default connect(mapStateToProps)(BudgetItem);

--- a/app/utils/formatAmount.js
+++ b/app/utils/formatAmount.js
@@ -16,4 +16,10 @@ export default function formatAmount(amount: number, showSign: boolean = true): 
     text: `${isNegative && showSign ? '-' : ''}${formatValue}`,
     isNegative,
   };
-}
+};
+
+export function formatPercent(amount: number): FormattedAmount {  
+  let roundAmount = Math.round(amount * 100) / 100;
+  const formatValue = Math.abs(roundAmount).toString();  
+  return "%" + `${formatValue}`    
+};


### PR DESCRIPTION
## Proposed Changes

Feature 
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items 

Acceptance Criteria 
Given that I have added at least one item to the budgeting grid 
When I click on that item 
Then I want to see a new page with a title corresponding to the item details 
And route should be dynamic with item ID in it 
And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow 
And a pie chart showing how much of the entire budget this item is contributing with should be on that page 
And no other items from the budget should be on that pie chart 
And there should be a back button to return back to the previous route 
And the view should be mobile and desktop compatible 

No special styling is necessary. 


## Screenshot

...
![image](https://user-images.githubusercontent.com/12088471/32957814-7aa67564-cb9b-11e7-867f-576571a9858b.png)


## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [ ] Comments in code
* [ ] Documentation written
